### PR TITLE
add pyelftools to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 termcolor==1.1.0
 pwntools==4.0.1
 r2pipe==1.4.2
+pyelftools==0.29


### PR DESCRIPTION
According https://stackoverflow.com/questions/77067937/python-modulenotfounderror-no-module-named-elftools-common-py3compat

It seem like 0.29 is last version has 'elftools.common.py3compat' support